### PR TITLE
Fix error checking logic in check() function

### DIFF
--- a/src/plctranslator/tia_translator.py
+++ b/src/plctranslator/tia_translator.py
@@ -38,7 +38,8 @@ def check(full_text: str) -> bool:
 
     potential_converted_full_info = potential_converted_dut + potential_converted_tcpou
 
-    if "TON_TIME" or "TOF_TIME" or "TP_TIME" or "CTU_INT" in potential_converted_full_info:
+    error_list = ["TON_TIME", "TOF_TIME", "TP_TIME", "CTU_INT"]
+    if any(keyword in potential_converted_full_info for keyword in error_list):
         result = False
 
     return result


### PR DESCRIPTION
This pull request fixes the error checking logic in the check() function. Previously, the logic was not correctly checking for the presence of certain keywords in the potential_converted_full_info string. This caused incorrect results in the check() function. The fix involves creating a list of keywords and using the any() function to check if any of the keywords are present in the string. This ensures that the error checking logic works correctly.