### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not conta…

### DIFF
--- a/.github/workflows/translate-plc-code.yml
+++ b/.github/workflows/translate-plc-code.yml
@@ -1,4 +1,6 @@
 name: Translate PLC code
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## GitHub Copilot Summary
This pull request makes a small update to the GitHub Actions workflow configuration by explicitly setting the required permissions for the workflow. This improves security by specifying that the workflow only needs read access to repository contents.

* Security improvement:
  * [`.github/workflows/translate-plc-code.yml`](diffhunk://#diff-b8cd7286d1d52986d01e2c7b396254f67f5cab74db4484dfa140982fb5995f6aR2-R3): Added `permissions` block to restrict workflow to read-only access for repository contents.